### PR TITLE
Added additional info to invalid path error

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -31,7 +31,7 @@ for path in "$@"; do
   if [[ -d $path || -f $path ]]; then
     ghr -u "${GITHUB_REPOSITORY%/*}" -r "${GITHUB_REPOSITORY#*/}" "${GITHUB_REF#refs/tags/}" "${path}"
   else
-    echo "Invalid path passed"
+    echo "Invalid path passed: ${path}"
     exit 1
   fi
 done


### PR DESCRIPTION
It is difficult to debug the invalid path error message without knowing the actual path that is being checked. This PR adds the ${path} variable to the error message.