### PR TITLE
use gcompat to provide compatibility layer for glibc

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM alpine:3.9 as base
 
-RUN apk add --no-cache jq curl
+RUN apk add --no-cache jq curl gcompat
 
 SHELL ["/bin/ash", "-o", "pipefail", "-c"]
 RUN curl -s https://api.github.com/repos/tcnksm/ghr/releases/latest | \


### PR DESCRIPTION
Alpine linux uses a minimal version of libc. The latest release of ghr is now dynamically linked and uses libc APIs not found in Alpine linux. Using [gcompat](https://git.adelielinux.org/adelie/gcompat) allows ghr to run.